### PR TITLE
Add geolocation as default for map and search

### DIFF
--- a/client/components/MapPicker.tsx
+++ b/client/components/MapPicker.tsx
@@ -30,6 +30,7 @@ export function MapPicker({
   const markerRef = useRef<mapboxgl.Marker | null>(null);
   const userMarkerRef = useRef<mapboxgl.Marker | null>(null); // 👈 marker for live location
   const watchIdRef = useRef<number | null>(null);
+  const initialLocationSet = useRef<boolean>(false);
 
   async function reverseGeocode(lng: number, lat: number): Promise<string | undefined> {
     try {
@@ -48,8 +49,12 @@ export function MapPicker({
   useEffect(() => {
     if (!mapContainer.current || mapRef.current) return;
 
-    const centerLng = value?.lng ?? -122.4194;
-    const centerLat = value?.lat ?? 37.7749;
+    // Default coordinates (San Francisco)
+    const defaultLng = -122.4194;
+    const defaultLat = 37.7749;
+    
+    const centerLng = value?.lng ?? defaultLng;
+    const centerLat = value?.lat ?? defaultLat;
 
     const map = new mapboxgl.Map({
       container: mapContainer.current,
@@ -87,6 +92,42 @@ export function MapPicker({
       const formatted = await reverseGeocode(lng, lat);
       onChange({ lat, lng }, formatted);
     });
+
+    // Get current location and set as default if no value provided
+    if (!value?.lat || !value?.lng) {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          async (position) => {
+            const { latitude, longitude } = position.coords;
+            
+            // Only set as default if no initial location has been set yet
+            if (!initialLocationSet.current) {
+              initialLocationSet.current = true;
+              
+              // Update marker position
+              markerRef.current!.setLngLat([longitude, latitude]);
+              
+              // Center map on current location
+              map.setCenter([longitude, latitude]);
+              map.setZoom(12); // Zoom in a bit more for current location
+              
+              // Get formatted address and call onChange
+              const formatted = await reverseGeocode(longitude, latitude);
+              onChange({ lat: latitude, lng: longitude }, formatted);
+            }
+          },
+          (error) => {
+            console.warn("Could not get current location:", error.message);
+            // If geolocation fails, keep using the default coordinates
+          },
+          {
+            enableHighAccuracy: true,
+            timeout: 10000,
+            maximumAge: 300000 // 5 minutes
+          }
+        );
+      }
+    }
 
     // 📌 Add Geolocate button (Mapbox built-in)
     const geolocateControl = new mapboxgl.GeolocateControl({

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -99,7 +99,6 @@ export default function Header() {
             { to: "/model", label: "Model" },
             { to: "/contribute", label: "Contribute" },
             { to: "/about", label: "About" },
-            { to: "/faq", label: "History" }
           ].map((item, index) => (
             <motion.div 
               key={item.to}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -33,6 +33,7 @@ export default function Index() {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const suggestionsRef = useRef<HTMLDivElement | null>(null);
+  const initialLocationSet = useRef<boolean>(false);
   
   const { suggestions, selectPlace, searchPlaces, clearSuggestions } = useMapboxPlaces();
 
@@ -57,6 +58,53 @@ export default function Index() {
     });
     setShowSuggestions(false);
   };
+
+  // Get current location on component mount
+  useEffect(() => {
+    if (initialLocationSet.current) return;
+    
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        async (position) => {
+          const { latitude, longitude } = position.coords;
+          
+          // Only set if no location has been set yet
+          if (!location.trim()) {
+            initialLocationSet.current = true;
+            setCoords({ lat: latitude, lng: longitude });
+            
+            // Get formatted address using reverse geocoding
+            try {
+              const token = "pk.eyJ1IjoiYWJkZWxyaGFtYW4xMjMiLCJhIjoiY21nOTBmbW5rMGI1NTJqc2E2N2pkNjRyMCJ9.fovjQp9aLuOxb4V4ruCWsw";
+              const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
+                `${longitude},${latitude}`
+              )}.json?access_token=${token}&limit=1`;
+              
+              const res = await fetch(url);
+              if (res.ok) {
+                const data = await res.json();
+                const placeName = data?.features?.[0]?.place_name;
+                if (placeName) {
+                  setLocation(placeName);
+                }
+              }
+            } catch (error) {
+              console.warn("Could not get location name:", error);
+              setLocation("Current Location");
+            }
+          }
+        },
+        (error) => {
+          console.warn("Could not get current location:", error.message);
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 300000 // 5 minutes
+        }
+      );
+    }
+  }, [location]);
 
   // Close suggestions when clicking outside
   useEffect(() => {


### PR DESCRIPTION
MapPicker and Index pages now use the user's current location as the default if no location is set, improving user experience by centering the map and search on their actual position. Also removed the 'History' link from the Header navigation.